### PR TITLE
Return the public key from prepare function

### DIFF
--- a/src/Core/KeyPair.php
+++ b/src/Core/KeyPair.php
@@ -306,6 +306,8 @@ class KeyPair
             // `publicKey` could not be interpreted.
             throw new RuntimeException("Invalid Private key for KeyPair creation. Please use hexadecimal notation (64|66 characters string) or the \\NEM\\Core\\Buffer class.");
         }
+
+	return $publicKey;
     }
 
     /**


### PR DESCRIPTION
When trying to create a new keypair using an existing public key, execution will halt because within the preparePublicKey function, there is no return, end result is a null key because of the following lines

```
if (null !== $publicKey) {
            // use provided `publicKey` parameter
            $this->publicKey = $this->preparePublicKey($publicKey);
        }
```

A possible alternative to the approach taken is to remove the variable assignment from the above statement.