### PR TITLE
PHP 7.4 compatibility in Core/Buffer

### DIFF
--- a/src/Core/Buffer.php
+++ b/src/Core/Buffer.php
@@ -602,7 +602,7 @@ class Buffer
         usort($items, function ($a, $b) use ($convertToBuffer) {
             $av = $convertToBuffer($a)->getBinary();
             $bv = $convertToBuffer($b)->getBinary();
-            return $av == $bv ? 0 : $av > $bv ? 1 : -1;
+            return $av == $bv ? 0 : ($av > $bv ? 1 : -1);
         });
 
         return $items;


### PR DESCRIPTION
Parantheses without ( ) are in PHP 7.4 deprecated and throw errors: https://www.php.net/manual/de/migration74.deprecated.php